### PR TITLE
fix: restart dnsmasq to honor configuration file

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -10,3 +10,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_dnsmasq_service(host):
     assert host.service("dnsmasq").is_running
     assert host.service("dnsmasq").is_enabled
+    result = host.run("journalctl -xeu dnsmasq --no-pager")
+    assert result.succeeded
+    assert "reading /etc/resolv.dnsmasq" in result.stdout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,9 +22,13 @@
     dest: /etc/dnsmasq.conf
   notify: restart dnsmasq
 
+  # The dnsmasq service is already started when installed via a package
+  # manager. It is required to restart the service to ensure that the
+  # service uses the proper configuration file.
 - name: start and enable dnsmasq
   systemd:
     daemon_reload: true
     name: dnsmasq
-    state: started
+    state: restarted
     enabled: true
+  changed_when: false


### PR DESCRIPTION
### Description

Restarts the `dnsmasq` service to honor the custom configuration file `/etc/dnsmasq.conf`.
