### PR TITLE
feat: add CentOS 8 ppc64le platform

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -10,6 +10,8 @@ jobs:
           python-version: 3.6
       - name: Install required dependencies
         run: pip install -r requirements.txt
+      - name: Enable execution of different multi-architecture containers
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - env:
           AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
           AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+
+  config.vm.provision "docker"
+
+  config.vm.provision "shell",
+    inline: "docker run --rm --privileged multiarch/qemu-user-static --reset -p yes"
+
+  config.vm.provision "shell",
+    inline: <<-SCRIPT
+apt-get -y install python3-venv
+python3 -m venv venv
+. venv/bin/activate
+pip install -r /vagrant/requirements.txt
+echo '. venv/bin/activate' >> ~/.bashrc
+SCRIPT
+end

--- a/molecule/docker/INSTALL.rst
+++ b/molecule/docker/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/docker/converge.yml
+++ b/molecule/docker/converge.yml
@@ -4,4 +4,4 @@
   tasks:
     - name: "Include ansible-role-dnsmasq"
       include_role:
-        name: "ansible-role-dnsmasq"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"

--- a/molecule/docker/converge.yml
+++ b/molecule/docker/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include ansible-role-dnsmasq"
+      include_role:
+        name: "ansible-role-dnsmasq"

--- a/molecule/docker/dockerfiles/Docker.ppc64le
+++ b/molecule/docker/dockerfiles/Docker.ppc64le
@@ -1,0 +1,13 @@
+FROM ppc64le/centos:7
+ENV container docker
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["/usr/sbin/init"]

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -4,10 +4,14 @@ dependency:
 driver:
   name: docker
 platforms:
-  - command: /sbin/init
-    image: ppc64le/centos:8
+  - capabilities:
+      - SYS_ADMIN
+    command: /sbin/init
+    dockerfile: dockerfiles/Docker.ppc64le
+    image: ppc64le/centos
     name: instance
-    pre_build_image: true
+    pre_build_image: false
+    privileged: true
     tmpfs:
       - /run
       - /tmp

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -1,0 +1,19 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - command: /sbin/init
+    image: ppc64le/centos:8
+    name: instance
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra

--- a/molecule/docker/tests/test_default.py
+++ b/molecule/docker/tests/test_default.py
@@ -1,0 +1,11 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+def test_dnsmasq_service(host):
+    assert host.service("dnsmasq").is_enabled

--- a/molecule/docker/tests/test_default.py
+++ b/molecule/docker/tests/test_default.py
@@ -8,4 +8,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_dnsmasq_service(host):
+    assert host.service("dnsmasq").is_running
     assert host.service("dnsmasq").is_enabled
+    result = host.run("journalctl -xeu dnsmasq --no-pager")
+    assert result.succeeded
+    assert "reading /etc/resolv.dnsmasq" in result.stdout

--- a/molecule/docker/verify.yml
+++ b/molecule/docker/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/molecule/docker/verify.yml
+++ b/molecule/docker/verify.yml
@@ -1,9 +1,0 @@
----
-# This is an example playbook to execute Ansible tests.
-
-- name: Verify
-  hosts: all
-  tasks:
-  - name: Example assertion
-    assert:
-      that: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,14 +51,21 @@
     state: restarted
   changed_when: false
 
+- name: Check if dhclient configuration exists
+  stat:
+    path: /etc/dhcp/dhclient.conf
+  register: result
+
 - name: Configure the default DNS resolver as a fallback option
   blockinfile:
     block: supersede domain-name-servers 127.0.0.1, 169.254.169.253;
     insertafter: EOF
     path: /etc/dhcp/dhclient.conf
     state: present
+  when: result.stat.exists
 
 - name: Apply changes to dhclient
   command: dhclient
   changed_when: false
   ignore_errors: true
+  when: result.stat.exists


### PR DESCRIPTION
### Description

Adds support for installing and configuring dnsmasq on CentOS 8 ppc64le.

### Update

After experimenting more, I was able to use the [multiarch/qemu-user-static](https://github.com/multiarch/qemu-user-static) Docker image to enable execution of multi-architecture Docker images.

I have included the following step in the workflow:

```
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
```

I also created a `Vagrantfile` to support local testing. To test locally, invoke the following commands:

```
$ vagrant up
$ vagrant ssh
$ source venv/bin/activate
$ cd /vagrant
$ molecule test -s docker
```