### PR TITLE
feat(BUILD-11536): disable systemd-resolved on ubuntu18.04

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ dnsmasq_nameservers:
 dnsmasq_neg_ttl: 60
 dnsmasq_port: 53
 dnsmasq_user: dnsmasq
+dnsmasq_search: ec2.internal

--- a/tasks/disable-systemd-resolved.yml
+++ b/tasks/disable-systemd-resolved.yml
@@ -2,3 +2,14 @@
   systemd:
     name: systemd-resolved
     enabled: no
+    state: stopped
+
+- name: Remove resolve.conf symlink
+  file:
+   path: "/etc/resolv.conf"
+   state: absent
+
+- name: Create /etc/resolv.conf
+  template:
+    dest: /etc/resolv.conf
+    src: etc/resolv.conf.j2

--- a/tasks/disable-systemd-resolved.yml
+++ b/tasks/disable-systemd-resolved.yml
@@ -1,5 +1,4 @@
 - name: Disable systemd-resolved
   systemd:
     name: systemd-resolved
-    state: stopped
     enabled: no

--- a/tasks/disable-systemd-resolved.yml
+++ b/tasks/disable-systemd-resolved.yml
@@ -8,6 +8,7 @@
   file:
    path: "/etc/resolv.conf"
    state: absent
+  changed_when: false
 
 - name: Create /etc/resolv.conf
   template:

--- a/tasks/disable-systemd-resolved.yml
+++ b/tasks/disable-systemd-resolved.yml
@@ -1,0 +1,5 @@
+- name: Disable systemd-resolved
+  systemd:
+    name: systemd-resolved
+    state: stopped
+    enabled: no

--- a/tasks/disable-systemd-resolved.yml
+++ b/tasks/disable-systemd-resolved.yml
@@ -1,7 +1,7 @@
 - name: Disable systemd-resolved
   systemd:
     name: systemd-resolved
-    enabled: no
+    enabled: false
     state: stopped
 
 - name: Remove resolve.conf symlink
@@ -14,4 +14,5 @@
   template:
     dest: /etc/resolv.conf
     src: etc/resolv.conf.j2
+    mode: 0644
   changed_when: false

--- a/tasks/disable-systemd-resolved.yml
+++ b/tasks/disable-systemd-resolved.yml
@@ -14,3 +14,4 @@
   template:
     dest: /etc/resolv.conf
     src: etc/resolv.conf.j2
+  changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,8 @@
     backup: true
     dest: /etc/dnsmasq.conf
     src: etc/dnsmasq.conf
+    group: "{{ dnsmasq_group }}"
+    mode: 0644
   notify:
     - restart dnsmasq
 
@@ -37,6 +39,8 @@
   template:
     dest: /etc/resolv.dnsmasq
     src: etc/resolv.dnsmasq.j2
+    group: "{{ dnsmasq_group }}"
+    mode: 0644
   notify:
     - restart dnsmasq
 
@@ -74,4 +78,4 @@
   include_tasks: disable-systemd-resolved.yml
   when:
     - ansible_distribution == "Ubuntu"
-    - ansible_distribution_major_version is version("18", "==")
+    - ansible_distribution_major_version is version("18", ">=")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,3 +69,9 @@
   changed_when: false
   ignore_errors: true
   when: result.stat.exists
+
+- name: Disable systemd-resolved if needed
+  include_tasks: disable-systemd-resolved.yml
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version is version("18", "==")

--- a/templates/etc/dnsmasq.conf
+++ b/templates/etc/dnsmasq.conf
@@ -17,3 +17,6 @@ domain-needed
 {% endif %}
 neg-ttl={{ dnsmasq_neg_ttl }}
 resolv-file=/etc/resolv.dnsmasq
+
+# Send ec2.internal queries to AWS DNS
+server=/ec2.internal/169.254.169.253

--- a/templates/etc/resolv.conf.j2
+++ b/templates/etc/resolv.conf.j2
@@ -1,0 +1,1 @@
+nameserver 127.0.0.1

--- a/templates/etc/resolv.conf.j2
+++ b/templates/etc/resolv.conf.j2
@@ -1,1 +1,4 @@
 nameserver 127.0.0.1
+{% if dnsmasq_search is defined %}
+search {{ dnsmasq_search }}
+{% endif %}

--- a/templates/etc/resolv.dnsmasq.j2
+++ b/templates/etc/resolv.dnsmasq.j2
@@ -2,6 +2,3 @@
 {% for nameserver in dnsmasq_nameservers %}
 nameserver {{ nameserver }}
 {% endfor %}
-{% if dnsmasq_search is defined %}
-search {{ dnsmasq_search }}
-{% endif %}

--- a/templates/etc/resolv.dnsmasq.j2
+++ b/templates/etc/resolv.dnsmasq.j2
@@ -2,3 +2,6 @@
 {% for nameserver in dnsmasq_nameservers %}
 nameserver {{ nameserver }}
 {% endfor %}
+{% if dnsmasq_search is defined %}
+search {{ dnsmasq_search }}
+{% endif %}


### PR DESCRIPTION
### Description

Disable systemd-resolved on ubuntu 18.04 because it would still use that service over dnsmasq
