### PR TITLE
fix: route aws zones via aws dns server on ec2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,4 @@ dnsmasq_neg_ttl: 60
 dnsmasq_port: 53
 dnsmasq_user: dnsmasq
 dnsmasq_search: ec2.internal
+dnsmasq_ec2: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,3 +4,5 @@
   hosts: all
   roles:
     - role: ansible-role-dnsmasq
+      vars:
+        dnsmasq_ec2: true

--- a/templates/etc/dnsmasq.conf
+++ b/templates/etc/dnsmasq.conf
@@ -18,5 +18,8 @@ domain-needed
 neg-ttl={{ dnsmasq_neg_ttl }}
 resolv-file=/etc/resolv.dnsmasq
 
+{% if dnsmasq_ec2 %}
 # Send ec2.internal queries to AWS DNS
 server=/ec2.internal/169.254.169.253
+server=/amazonaws.com/169.254.169.253
+{% endif %}


### PR DESCRIPTION
### Description

Adds rules to send aws zone requests to aws dns server.
ec2.internal is needed for local dns names including hostname
amazonaws.com is needed mostly for EFS. Everything else in that zone resolves fine via other DNS servers too.

Since amazonaws.com config can mess up static hosts that don't have access to aws dns, I've added a var `dnsmasq_ec2` so we can control where we create that config and where not. Default is false.
