### PR TITLE
fix(BUILD-12363): reverse lookup on ec2 instances

### DIFF
--- a/templates/etc/dnsmasq.conf
+++ b/templates/etc/dnsmasq.conf
@@ -22,4 +22,5 @@ resolv-file=/etc/resolv.dnsmasq
 # Send ec2.internal queries to AWS DNS
 server=/ec2.internal/169.254.169.253
 server=/amazonaws.com/169.254.169.253
+server=/10.in-addr.arpa/169.254.169.253
 {% endif %}


### PR DESCRIPTION
### Description

This fixes reverse lookups on EC2 hosts

```
ubuntu@ip-10-122-0-197:~$ dig -x 10.122.0.197

; <<>> DiG 9.11.3-1ubuntu1.8-Ubuntu <<>> -x 10.122.0.197
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 27645
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;197.0.122.10.in-addr.arpa.	IN	PTR

;; ANSWER SECTION:
197.0.122.10.in-addr.arpa. 229	IN	PTR	ip-10-122-0-197.ec2.internal.

# Server Configuration
;; Query time: 0 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Fri Nov 20 18:03:28 UTC 2020
;; MSG SIZE  rcvd: 96

```
