### PR TITLE
fix(BUILD-14944): added resolv.conf insertion for s390x

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,17 @@
     mode: 0644
   notify:
     - restart dnsmasq
+- name: Insert resolv.conf reference for certain s390x hosts
+  ansible.builtin.lineinfile:
+    path: /etc/resolv.conf
+    state: present
+    insertafter: '^search '
+    line: 'nameserver 127.0.0.1'
+  tags: test
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_machine == "s390x"
+    - ansible_distribution_version == "8.3"
 
   # The dnsmasq service is already started when installed via a package
   # manager. It is required to restart the service to ensure that the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,6 @@
     state: present
     insertafter: '^search '
     line: 'nameserver 127.0.0.1'
-  tags: test
   when:
     - ansible_os_family == "RedHat"
     - ansible_machine == "s390x"


### PR DESCRIPTION
this change inserts a localhost reference to allow the system to hit dnsmasq for queries 